### PR TITLE
Fixed a bug in single + added code for plotting diffusion distance ov…

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -25,6 +25,8 @@ def main():
     save_dir = os.getcwd()
     saveparams = [save_dir, "anim_1"]
 
+    graphical_out.plot_diff_dist(system.site_list[0], t_list, exc_list)
+
     graphical_out.animate_3D(system.site_list, t_list, exc_list, interval = 500, padding = 0, save_params = saveparams) 
     # This one saves to current working directory
     # graphical_out.animate_3D(system.site_list, t_list, exc_list, interval = 100, save_params = None)

--- a/exc_diff/single.py
+++ b/exc_diff/single.py
@@ -35,8 +35,8 @@ def single(system, start_time, end_time):
 
         exc_site = my_sys.get_excited_sites()
         # print(exc_site.get_position())
-        print(exc_site[0])
-        exc_list.append(exc_site[0])
+        # print(exc_site[0])
+        exc_list.append([exc_site[0]])
         # print('Site at beginning of time step is ', exc_site)
         # if t == start_time:
             # start_pos = exc_site[0].get_position()

--- a/output/graphical_out.py
+++ b/output/graphical_out.py
@@ -132,9 +132,9 @@ def find_site(site_list, site):
 #
 # Returns: True, for now
 # 
-def plot_sites(site_list, color = COLORS[0], alpha = 1):
+def plot_sites(site_list, exc_list = None, color = COLORS[0], alpha = 1):
     if not (isinstance(site_list, list)) or (site_list is None):
-        raise ValueError("Site List must be a non-empty array")  
+        raise ValueError("Site List must be a non-empty array")
     
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -143,9 +143,43 @@ def plot_sites(site_list, color = COLORS[0], alpha = 1):
     sites_nice = process_sites(site_list)
     ax.scatter(sites_nice[:,0], sites_nice[:,1], sites_nice[:,2], c = color, alpha = alpha)
 
+    if exc_list is not None:
+        sites_nice = process_sites(exc_list)
+        ax.scatter(sites_nice[:,0], sites_nice[:,1], sites_nice[:,2], c = COLORS[3], alpha = alpha)
+
     plt.show()
 
     return True
+
+# Plot diffusion distance
+def plot_diff_dist(start_site, t_list, exc_list, alpha = 1):
+    if not (isinstance(exc_list, list)) or (exc_list is None):
+        raise ValueError("Site List must be a non-empty array")
+    
+    start_pos = start_site.get_position()
+
+    # Generate data of monotonously increasing distances
+    dmax_outer = -1
+    d_arr = []
+    t_arr = []
+    for i in range(1, len(exc_list)):
+        sites_nice = process_sites(exc_list[i])
+        dist = np.max(np.linalg.norm(sites_nice- start_pos))
+        # print(dist)
+        if dist > dmax_outer:
+            dmax_outer = dist
+            d_arr.append(dist)
+            t_arr.append(t_list[i])
+
+    plt.figure()
+    plt.plot(t_arr, d_arr)
+    plt.xlabel('t')
+    plt.ylabel('Diffusion distance')
+
+    plt.show()
+
+    return True
+
 
 # Excited Sites Animation
 # Params: 
@@ -242,26 +276,15 @@ def animate_3D(site_list, t_list, exc_list, save_params = None, site_rad = 100, 
 
 # Main function just runs a bunch of tests
 def main():
+    import exc_diff.single as ex
+
     in_file = sys.argv[1]
 
     system_type, site_list, dimen, rate, model_type, start_time, end_time = inputprocessor.process_input(in_file)
 
-    site_list_nice = process_sites(site_list)
-    
-    print("site_list_nice: \n" + str(site_list_nice))
+    t_list, exc_list = ex.single(system_type, start_time, end_time)
 
-    # exc_list = [site_list_nice[0], site_list_nice[1], site_list_nice[2]]
 
-    exc_list = site_list
-
-    # print(exc_list)
-
-    for site in exc_list:
-        print(find_site(site_list_nice, site.position))
-
-    # plot_sites(site_list, color = COLORS[3])
-
-    # animate_scatter(site_list)
 
     # animate_3D(site_list, np.ones(3000), [], save_params = None)
 

--- a/system.py
+++ b/system.py
@@ -75,7 +75,7 @@ class System(ABC):
         return self.exc_list
 
     def transfer_charge(self, site_old, site_new):
-        print("Exc_sites #: " + str(len(self.exc_list)))
+        # print("Exc_sites #: " + str(len(self.exc_list)))
 
         # print(site_old.get_position())
 


### PR DESCRIPTION
Just added extra modularity in graphical out so that diffusion distance can be printed. 

I changed `exc_list.append(exc_site[0])` to `exc_list.append([exc_site[0]]).` This is because, in general, we can have a list of excited sites at any one time, so exc_list should be a list of sites for each timestep. 